### PR TITLE
Valence force

### DIFF
--- a/WeLD.js
+++ b/WeLD.js
@@ -90,7 +90,7 @@
   // setup physics resources ////////////////////////////////////////////////
   ///////////////////////////////////////////////////////////////////////////
 
-  var edgeLen = 20;
+  var edgeLen = 100;
   lattice = Physics.Lattice;
   lattice.setUI(ui);
   lattice.setShowEdges(true);
@@ -114,15 +114,15 @@
   ui.setData(lattice.data);
   verletController = Physics.Verlet;
 
-  //lattice.setForces({name: "Test Force", params: [], color: "red"})
-  // lattice.setInterAtomicForces(
-  //  {
-  //    name: "spring",
-  //    params: [1e-1,edgeLen],
-  //    color: "red"
-  //  },
-  //  springPredicate
-  //);
+  lattice.setForces({name: "Test Force", params: [], color: "red"})
+  lattice.setInterAtomicForces(
+   {
+     name: "spring",
+     params: [10, edgeLen],
+     color: "red"
+   },
+   springPredicate
+  );
 
   // Setup valence angles
   Physics.initValence(lattice, 1);

--- a/modules/physics/ForceMap.js
+++ b/modules/physics/ForceMap.js
@@ -2,7 +2,14 @@
 Physics.Forcemap
 This class stores all of the predefined forces that
 velocityVerlet uses. The forces should all have the same function signature:
-(d, data, params) => {forceX, forceY, forceZ), where
+(d, data, params) =>
+[
+[index1, {x: force1x, y: force1y, z: force1z}],
+[index2, {x: force2x, y: force2y, z: force2z],
+...
+]
+i.e. it should return a list of 2-tuples (arrays) containing the index
+of the node the force should act on as well as the actual force.
 d is the data for one node, data is the data for all nodes, and params is an array
 containing all the parameters necessary to compute the force, e.g. spring constants etc.
 The forces should all the pure functions, i.e. they should not mutate any nodes or have side effects. They
@@ -13,7 +20,7 @@ class ForceMap {
   constructor() {
     this.testForce = function (d, data, params) {
       // just for testing purposes
-      return { x: 1, y: 1, z: 1 };
+      return [[d.id, {x: 100, y: 100, z: 0}]]
     };
 
     this.spring = function (d, data, params) {
@@ -31,12 +38,11 @@ class ForceMap {
       const equilibrium = Physics.Vector.scale(nodesLen, unitSeparation);
       const extension = Physics.Vector.sub(separation, equilibrium);
 
-      // begin debug here
-      fx = -k * extension.x;
-      fy = -k * extension.y;
-      fz = -k * extension.z;
+      const fx = -k * extension.x;
+      const fy = -k * extension.y;
+      const fz = -k * extension.z;
 
-      return { x: fx, y: fy, z: fz };
+      return [[d.id, {x: fx, y: fy, z: fz}]]
     };
 
     this.valenceAngle = function (d, data, params) {
@@ -64,7 +70,7 @@ class ForceMap {
 
       var fc = Physics.Vector.scale(fcFactor, pc);
       var fb = Physics.Vector.scale(-1, Physics.Vector.add(fa, fc));
-      return fb;
+      return [[index1, fa], [d.id, fb], [index2, fc]];
     };
 
     this.forceMap = {

--- a/modules/physics/Verlet.js
+++ b/modules/physics/Verlet.js
@@ -1,37 +1,36 @@
-const Verlet = function(d, data)
-{
-  const dt = 1e-1;
+const Verlet = function(d, data) {
+    const dt = 1e-1;
 
-  // calculate total force acting on the node
-  this.velocityVerlet = function(d, data){
+    // calculate total force acting on the node
+    this.velocityVerlet = function(d, data) {
 
-  // TODO: implement forces due to a potential to get total force on a node.
-    let fi = {x:0, y:0, z:0};
+        // TODO: implement forces due to a potential to get total force on a node.
+        let fi = { x: 0, y: 0, z: 0 };
 
-    d.forces.forEach(({name, params, color}) => {
-    //  if(Physics.ForceMap.has(name))
-      {
-        force = Physics.ForceMap[name];
-        const {x, y, z} = force(d, data, params);
-        fi.x += x;
-        fi.y += y;
-        fi.z += z;
-      }
-    })
+        d.forces.forEach(({ name, params, color }) => {
+            //  if(Physics.ForceMap.has(name))
+            {
+                force = Physics.ForceMap[name];
+                const { x, y, z } = force(d, data, params);
+                fi.x += x;
+                fi.y += y;
+                fi.z += z;
+            }
+        })
 
-    // leapfrog step
-    const v_half = Physics.Vector.add(d.vi, Physics.Vector.scale(0.5*(1/d.m)*dt, fi));
-    const rf = Physics.Vector.add(d.ri, Physics.Vector.scale(dt, v_half));
-    const vf = Physics.Vector.add(v_half,Physics.Vector.scale(dt*0.5*(1/d.m),fi));
+        // leapfrog step
+        const v_half = Physics.Vector.add(d.vi, Physics.Vector.scale(0.5 * (1 / d.m) * dt, fi));
+        const rf = Physics.Vector.add(d.ri, Physics.Vector.scale(dt, v_half));
+        const vf = Physics.Vector.add(v_half, Physics.Vector.scale(dt * 0.5 * (1 / d.m), fi));
 
-    d.vf = vf
-    d.rf = rf
-}
+        d.vf = vf
+        d.rf = rf
+    }
 
-this.updateState = function(d,data){
-    d.ri = d.rf;
-    d.vi = d.vf;
-}
+    this.updateState = function(d, data) {
+        d.ri = d.rf;
+        d.vi = d.vf;
+    }
 
 }
 

--- a/modules/physics/Verlet.js
+++ b/modules/physics/Verlet.js
@@ -4,27 +4,28 @@ const Verlet = function(d, data) {
     // calculate total force acting on the node
     this.velocityVerlet = function(d, data) {
 
-        // TODO: implement forces due to a potential to get total force on a node.
-        let fi = { x: 0, y: 0, z: 0 };
-
         d.forces.forEach(({ name, params, color }) => {
             //  if(Physics.ForceMap.has(name))
             {
                 force = Physics.ForceMap[name];
-                const { x, y, z } = force(d, data, params);
-                fi.x += x;
-                fi.y += y;
-                fi.z += z;
+                const actions = force(d, data, params);
+                actions.forEach(action => {
+                    const [index, force] = action
+                    const {x, y, z} = force;
+                    const node = data[index]
+                    // leapfrog step
+                    const v_half = Physics.Vector.add(node.vi, Physics.Vector.scale(0.5 * (1 / node.m) * dt, force));
+                    const rf = Physics.Vector.add(node.ri, Physics.Vector.scale(dt, v_half));
+                    const vf = Physics.Vector.add(v_half, Physics.Vector.scale(dt * 0.5 * (1 / node.m), force));
+
+                    node.vf = vf
+                    node.rf = rf
+
+                })
+
             }
         })
 
-        // leapfrog step
-        const v_half = Physics.Vector.add(d.vi, Physics.Vector.scale(0.5 * (1 / d.m) * dt, fi));
-        const rf = Physics.Vector.add(d.ri, Physics.Vector.scale(dt, v_half));
-        const vf = Physics.Vector.add(v_half, Physics.Vector.scale(dt * 0.5 * (1 / d.m), fi));
-
-        d.vf = vf
-        d.rf = rf
     }
 
     this.updateState = function(d, data) {


### PR DESCRIPTION
Currently, on the `master` branch, our verlet controller expects the forces defined in `Forcemap.js` to just return the force to apply to the node. This will not work for some forces, like the valence bonding interaction we are trying to implement, as it needs to apply a force to 3 different nodes for each interaction. So, I have patched this to allow the forces to act on more than just one node, while still retaining their convenient pure function structure. Now, instead of just returning a force,
they return an array of 2-tuples (also arrays), where in each tuple, the first element is the index of the node to act on, and the second element is the force to apply to that node. I have also patched `Verlet.js` to accomodate for this, and tested that it works.